### PR TITLE
Branch Maven 3.0 -> Handle primitive types in ReflectionUtil

### DIFF
--- a/src/main/java/org/scala_tools/maven/plexus/converters/ReflectionUtil.scala
+++ b/src/main/java/org/scala_tools/maven/plexus/converters/ReflectionUtil.scala
@@ -63,14 +63,15 @@ object ReflectionUtil {
       target.isAssignableFrom(source)
 
     target.toString match {
-      case "int"    => isPrimitive[java.lang.Integer]
-      case "short"  => isPrimitive[java.lang.Short]
-      case "long"   => isPrimitive[java.lang.Long]
-      case "float"  => isPrimitive[java.lang.Float]
-      case "double" => isPrimitive[java.lang.Double]
-      case "char"   => isPrimitive[java.lang.Character]
-      case "byte"   => isPrimitive[java.lang.Byte]
-      case _        => isClass
+      case "boolean" => isPrimitive[java.lang.Boolean]
+      case "int"     => isPrimitive[java.lang.Integer]
+      case "short"   => isPrimitive[java.lang.Short]
+      case "long"    => isPrimitive[java.lang.Long]
+      case "float"   => isPrimitive[java.lang.Float]
+      case "double"  => isPrimitive[java.lang.Double]
+      case "char"    => isPrimitive[java.lang.Character]
+      case "byte"    => isPrimitive[java.lang.Byte]
+      case _         => isClass
     }
 
   }

--- a/src/test/java/org/scala_tools/maven/plexus/converters/DummyScalaMojo.scala
+++ b/src/test/java/org/scala_tools/maven/plexus/converters/DummyScalaMojo.scala
@@ -2,15 +2,15 @@ package org.scala_tools.maven.plexus.converters
 
 import org.scala_tools.maven.mojo.annotations._
 
-@goal("dummy")
-@phase("compile")
-@requiresDependencyResolution("compile")
+@goal("dummy") @phase("compile") @requiresDependencyResolution("compile")
 class DummyScalaMojo {
-  @parameter
-  @expression("${project.build.finalName}")
+  @parameter @expression("${project.build.finalName}")
   var dummyVar: String = _
   @parameter
   var otherVar: Int = _
+
+  @parameter
+  var aBoolean: Boolean = _
   @parameter
   var aShort: Short = _
   @parameter

--- a/src/test/java/org/scala_tools/maven/plexus/converters/TestRelfectionUtil.scala
+++ b/src/test/java/org/scala_tools/maven/plexus/converters/TestRelfectionUtil.scala
@@ -39,6 +39,9 @@ class TestRelfectionUtil {
     injectIntoVar(mojo, "otherVar", Int.box(100))
     assertEquals(100, mojo.otherVar);
 
+    injectIntoVar(mojo, "aBoolean", Boolean.box(true))
+    assertEquals(true, mojo.aBoolean);
+
     injectIntoVar(mojo, "aShort", Short.box(2))
     assertEquals(2, mojo.aShort);
 


### PR DESCRIPTION
Hi Josh,
I'm developing a maven plugin for scalastyle in scala using scala-mojo-support. And I wanted add boolean configuration parameter called verbose. However currently mojo does not handle primitive parameters. Throws Can not coerce: java.lang.Boolean into a boolean 
I'have fixed ReflectionUtil of mojo to handle boxed primitive types.  Could you please pull these changes into maven-3.0 branch.

Regards
Das
