### PR TITLE
Cross build for Scala 2.9 and 2.10

### DIFF
--- a/parent-pom.xml
+++ b/parent-pom.xml
@@ -3,12 +3,11 @@
   <modelVersion>4.0.0</modelVersion>
   <properties>
     <maven.version>3.0</maven.version>
-    <scala.version>2.9.0</scala.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <groupId>com.jsuereth</groupId>
   <artifactId>scala-mojo-support</artifactId>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
   <version>0.5-SNAPSHOT</version>
   <name>Scala Mojo Support</name>
   <description>The scala-mojo-support project contains helper code for creating Mojos in scala.</description>
@@ -129,7 +128,7 @@
         <configuration>
           <scalaVersion>${scala.version}</scalaVersion>
           <args>
-            <arg>-target:jvm-1.5</arg>
+            <arg>-target:jvm-${target.jvm}</arg>
             <arg>-no-specialization</arg>
             <arg>-deprecation</arg>
             <!--<arg>-Ystop:erasure</arg>-->

--- a/pom-2.10.0-RC2.xml
+++ b/pom-2.10.0-RC2.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.jsuereth</groupId>
+    <artifactId>scala-mojo-support</artifactId>
+    <version>0.5-SNAPSHOT</version>
+    <relativePath>./parent-pom.xml</relativePath>
+  </parent>
+  <properties>
+    <scala.version>2.10.0-RC2</scala.version>
+    <target.jvm>1.6</target.jvm>
+  </properties>
+  <artifactId>scala-mojo-support_2.10.0-RC2</artifactId>
+  <packaging>jar</packaging>
+</project>

--- a/pom-2.9.xml
+++ b/pom-2.9.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.jsuereth</groupId>
+    <artifactId>scala-mojo-support</artifactId>
+    <version>0.5-SNAPSHOT</version>
+    <relativePath>./parent-pom.xml</relativePath>
+  </parent>
+  <properties>
+    <scala.version>2.9.0</scala.version>
+    <target.jvm>1.5</target.jvm>
+  </properties>
+  <artifactId>scala-mojo-support_2.9</artifactId>
+  <packaging>jar</packaging>
+</project>

--- a/src/main/java/org/scala_tools/maven/mojo/annotations/annotations.scala
+++ b/src/main/java/org/scala_tools/maven/mojo/annotations/annotations.scala
@@ -10,7 +10,7 @@ object MavenAnnotation {
     def unapply(ann: String) = try {
       Some(Class.forName(ann + "$").getField("MODULE$").get(null))
     } catch {
-      case _ => None
+      case _: Throwable => None
     }
   }
 

--- a/src/main/java/org/scala_tools/maven/mojo/util/Resource.scala
+++ b/src/main/java/org/scala_tools/maven/mojo/util/Resource.scala
@@ -18,8 +18,7 @@ object Resource {
 import java.io._
 object RichBufferedReader {
   implicit def pimpBufferedReader(reader : BufferedReader) = new Iterable[String] {
-    override def elements = new BufferedReaderIterator(reader)
-    def iterator = elements
+    override def iterator = new BufferedReaderIterator(reader)
   }
 }
 

--- a/src/main/java/org/scala_tools/maven/plexus/ScalaComponentFactory.scala
+++ b/src/main/java/org/scala_tools/maven/plexus/ScalaComponentFactory.scala
@@ -44,7 +44,7 @@ class ScalaComponentFactory extends AbstractComponentFactory {
 	       (for {        
 	        child <- componentDescriptor.getConfiguration.getChildren
 	        if child.getName.startsWith(constructorPrefix)
-	        val order = child.getName.substring(constructorPrefix.length)
+	        order = child.getName.substring(constructorPrefix.length)
 	      } yield (child, order)).toList.sortWith(_._2 < _._2).map(_._1).toArray
       } else {
         Array()


### PR DESCRIPTION
Use a separate POM for each minor version of Scala, and add it to the artifactId.  Could do a _2.9.1, _2.9.2, etc., like SBT convention, but this won't be used by SBT anyway, so this is the minimum that supports binary compatibility.  

Alternatively, 0.5 could just be the Scala 2.10.x release, but it's trivial to support both in case anybody enhances this.

I'll move the 2.10.0-RC2 pom to a simple _2.10 once it's final.  Mainly want to get a Scalate port up and running, and this is one of our blockers.
