### PR TITLE
Support parameter inheritance

### DIFF
--- a/src/it/test-mojo-project/src/it/testEcho/invoker.properties
+++ b/src/it/test-mojo-project/src/it/testEcho/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals= clean test-scala:echo
+invoker.goals= clean test-scala:echo test-scala:child-echo

--- a/src/it/test-mojo-project/src/it/testEcho/validate.groovy
+++ b/src/it/test-mojo-project/src/it/testEcho/validate.groovy
@@ -1,16 +1,15 @@
 def echoString = "HAI"
-def logFile = new File(basedir, "target/echo.txt")
-//Look for echo string
-def found = false;
+def fileNames = ["echo.txt", "child.txt"]
 
-System.out.println("Logfile = " + logFile)
+fileNames.each({ fileName ->
+    def found = false
+    def logFile = new File(basedir, "target/${fileName}")
+    logFile.eachLine({ line ->
+        if(line.startsWith(echoString)) {
+            found = true
+        }
+    });
+    assert found
+})
 
-logFile.eachLine({ line ->
-   System.out.println("Checking line: " + line)
-   if(line.startsWith(echoString)) {
-   	 found = true;
-   }
-});
-
-assert found
 true

--- a/src/it/test-mojo-project/src/main/scala/org/scala_tools/mojo/TestMojo.scala
+++ b/src/it/test-mojo-project/src/main/scala/org/scala_tools/mojo/TestMojo.scala
@@ -32,11 +32,20 @@ class TestMojo extends AbstractMojo {
     if(!outputDirectory.exists) {
        outputDirectory.mkdirs()
     }
-    val file = new File(outputDirectory, "echo.txt")
+    val file = new File(outputDirectory, fileName)
     val output = new PrintStream(new FileOutputStream(file))
     
     output.println("HAI")
     output.close()
     
   }
+
+  val fileName = "echo.txt"
+}
+
+@goal("child-echo")
+@phase("process-sources")
+@requiresProject
+class ChildMojo extends TestMojo {
+  override val fileName = "child.txt"
 }

--- a/src/main/java/org/scala_tools/maven/mojo/extractor/MojoExtractorCompiler.scala
+++ b/src/main/java/org/scala_tools/maven/mojo/extractor/MojoExtractorCompiler.scala
@@ -18,7 +18,7 @@ class MojoExtractorCompiler(project: MavenProject) extends MavenProjectTools wit
       val settings = new Settings();
       //TODO - Set settings
       settings.classpath.value = getCompileClasspathString(project)
-      settings.stop.tryToSetColon(List("superaccessors"))
+      settings.stop.tryToSetColon(List("constructors"))
       settings.sourcepath.tryToSet(project.getCompileSourceRoots().asInstanceOf[java.util.List[String]].toList)
       val reporter = new ConsoleReporter(settings);
       (settings, reporter)


### PR DESCRIPTION
Based on https://github.com/fusesource/mvnplugins/commit/218166deccf02b63e9bffecea3b17f5e2ae14099.

Seen in the wild in https://github.com/scalate/scalate/blob/94e67bb9e1de6aa2fc8950f289c48b2d4806e21b/maven-scalate-plugin/src/main/java/org/fusesource/scalate/maven/SiteGenMojo.scala.

Confession: I don't understand the compiler API enough yet  to understand the code change, but it makes the integration test work.  

I'm still chewing on the other half of the mvnplugins commit, but I think Scalate needs that, too.  This is probably Part 1 of 2.
