### PR TITLE
Generates <executeGoal> / <executePhase> from @goal and @phase annotations, which is incorrect

### DIFF
--- a/src/main/java/org/scala_tools/maven/mojo/extractor/MojoExtractionInfo.scala
+++ b/src/main/java/org/scala_tools/maven/mojo/extractor/MojoExtractionInfo.scala
@@ -19,10 +19,8 @@ trait MojoExtractionInfo {
       annotation match {
         case goal(name) =>
           desc.setGoal(name)
-          desc.setExecuteGoal(name)
         case phase(name) =>
           desc.setPhase(name)
-          desc.setExecutePhase(name)
         case configurator(roleHint) =>
           desc.setComponentConfigurator(roleHint)
         case executeGoal(value) =>


### PR DESCRIPTION
When writing a Scala mojo, if no `@executeGoal` or `@executePhase` annotation is present on the mojo, the plugin descriptor generated has `<executeGoal>` and `<executePhase>` elements anyway, taken from the `@goal` and `@phase` annotations. This is wrong; those elements should be generated from `@executeGoal` and `@executePhase` annotations only.

This change fixes it.
