### PR TITLE
Scala mojos spam lots of "processing child" messages

### DIFF
--- a/src/main/java/org/scala_tools/maven/plexus/ScalaComponentConfigurator.scala
+++ b/src/main/java/org/scala_tools/maven/plexus/ScalaComponentConfigurator.scala
@@ -66,7 +66,6 @@ class ScalaConfigurationConverter extends AbstractConfigurationConverter {
                                 listener : ConfigurationListener) : AnyRef = { 
 		
 		var retValue = fromExpression( configuration, expressionEvaluator, someType );
-		System.err.println("Result of expression evaluation: " + retValue);
     if ( retValue == null ) {
       try {
         // it is a "composite" - we compose it from its children. It does not have a value of its own
@@ -95,12 +94,10 @@ class ScalaConfigurationConverter extends AbstractConfigurationConverter {
 		listener : ConfigurationListener)  {
 		//TODO - Inject into component the configuration properties.
 		val items = configuration.getChildCount();
-		System.err.println("Processing Configuration for child elements");
     for (  i <- 0 until items ) {
       val childConfiguration = configuration.getChild( i );
 
       val elementName = childConfiguration.getName();
-      System.err.println("Processing child [" + elementName + "]");
 
       //TODO - Make sure the var setter is working correctly and we're passing the correct information to it.
       //TODO - Make sure we can handle "property object" configuration items.


### PR DESCRIPTION
When running a plugin that uses scala-mojo-support, messages like the following show up during the user's Maven build:

```
Processing Configuration for child elements
Processing child [oneParameter]
Processing child [anotherParameter]
```

This change removes them, 'cause silence is golden. :D
