### PR TITLE
Updated version to Scala 2.11 and fixed a minor change in Scala API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
   <modelVersion>4.0.0</modelVersion>
   <properties>
     <maven.version>3.0.4</maven.version>
-    <scala.version>2.10.0</scala.version>
+    <scala.version>2.11.2</scala.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <groupId>com.jsuereth</groupId>
-  <artifactId>scala-mojo-support_2.10</artifactId>
+  <artifactId>scala-mojo-support_2.11</artifactId>
   <packaging>jar</packaging>
   <version>0.5.1-SNAPSHOT</version>
   <name>Scala Mojo Support</name>
@@ -109,7 +109,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>compile</id>
@@ -129,7 +129,7 @@
         <configuration>
           <scalaVersion>${scala.version}</scalaVersion>
           <args>
-            <arg>-target:jvm-1.5</arg>
+            <arg>-target:jvm-1.6</arg>
             <arg>-no-specialization</arg>
             <arg>-deprecation</arg>
             <!--<arg>-Ystop:erasure</arg>-->

--- a/src/main/java/org/scala_tools/maven/mojo/extractor/MojoExtractorCompiler.scala
+++ b/src/main/java/org/scala_tools/maven/mojo/extractor/MojoExtractorCompiler.scala
@@ -18,7 +18,7 @@ class MojoExtractorCompiler(project: MavenProject) extends MavenProjectTools wit
       val settings = new Settings();
       //TODO - Set settings
       settings.classpath.value = getCompileClasspathString(project)
-      settings.stop.tryToSetColon(List("constructors"))
+      settings.stopAfter.tryToSetColon(List("constructors"))
       settings.sourcepath.tryToSet(project.getCompileSourceRoots().asInstanceOf[java.util.List[String]].toList)
       val reporter = new ConsoleReporter(settings);
       (settings, reporter)


### PR DESCRIPTION
 settings.stop was defined as equal to settings.stopAfter and was removed from Scala 2.11 branch
Updated targetVM to 1.6 because 1.5 is set as deprecated

I think this could be worth a stable version deploy :)

Cheers.
Richard
